### PR TITLE
Changed toHtml() method

### DIFF
--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -223,9 +223,9 @@ What we just did was moving fast through the amber state into the red.
 
     class Markdown
     {
-        public function toHtml()
+        public function toHtml($argument1)
         {
-            // TODO: implement
+            // TODO: write logic here
         }
     }
 


### PR DESCRIPTION
There is a small discrepancy in the manual.
Maybe, the implementation of `run` has changed since it was written?
