### PR TITLE
Updated list of formatters to match 2.0.1-PREVIEW

### DIFF
--- a/cookbook/configuration.rst
+++ b/cookbook/configuration.rst
@@ -55,11 +55,11 @@ formatter, use ``formatter.name``:
 
 Available formatters are:
 
-* pretty
-* dot
-* nyan
-* html/h
 * progress (default)
+* html
+* pretty
+* junit
+* dot
 
 Extensions
 ----------


### PR DESCRIPTION
While playing around with phpspec, I noticed that docs about formatters aren't up to date. So I fixed it. 
