### PR TITLE
added explanation on how to run distinct specs

### DIFF
--- a/cookbook/configuration.rst
+++ b/cookbook/configuration.rst
@@ -42,6 +42,11 @@ the classes it tests. For instance, the above ``acme_suite`` will be used when
 running ``phpspec run Acme\TheLib``, ``phpspec run spec\Acme\TheLib`` or
 any classes in that namespace (e.g. ``phpspec run Acme\TheLib\Section\Foo``).
 
+This assumes you that the specs you are trying to run are in the same directory
+from where you started phpspec. For instance, if your Acme namespace is located
+in the ``src`` directory (``src/Acme``) you would run ``phpspec run src/Acme`` 
+to run all specs in the ``Acme`` namespace.
+
 Formatter
 ---------
 


### PR DESCRIPTION
As per this issue https://github.com/phpspec/phpspec/issues/265 I added a new paragraph to the configuration docs detailing how to run a particular namespace/class if these aren't stored in the project root.
